### PR TITLE
Semantic keybindings

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,9 +25,9 @@
       <div class="collapse navbar-collapse" id="ts-nav-collapse">
         <% if user_signed_in? %>
           <ul class="nav navbar-nav">
-            <li><%= link_to "Tags", tags_path, data: { keybinding: '1' } %></li>
-            <li><%= link_to "Tasks", tasks_path, data: { keybinding: '2' } %></li>
-            <li><%= link_to "Time Entries", time_entries_path, data: { keybinding: '3' } %></li>
+            <li><%= link_to "Tags", tags_path, data: { keybinding: 'a' } %></li>
+            <li><%= link_to "Tasks", tasks_path, data: { keybinding: 's' } %></li>
+            <li><%= link_to "Time Entries", time_entries_path, data: { keybinding: 'e' } %></li>
           </ul>
         <% end %>
 
@@ -36,8 +36,8 @@
             <li><%= link_to current_user.username, edit_user_registration_path(current_user), id: ('admin' if current_user.admin?) %></li>
             <li><%= link_to "Sign out", destroy_user_session_path, method: :delete %></li>
           <% else %>
-            <li><%= link_to "Log in", new_user_session_path %></li>
-            <li><%= link_to "Sign up", new_user_registration_path %></li>
+            <li><%= link_to "Log in", new_user_session_path, data: { keybinding: 'l' } %></li>
+            <li><%= link_to "Sign up", new_user_registration_path, data: { keybinding: 'i' } %></li>
           <% end %>
         </ul>
       </div>


### PR DESCRIPTION
The 1, 2, and 3 keybindings for changing the page were conflicting with
Alt-1, Alt-2, and Alt-3 for changing tabs. I decided to make these more
semantic in addition to removing the conflict as well as adding two
additional keybindings. The new keybindings are as follows:

- t`A`gs
- ta`S`ks
- time `E`ntries
- `L`og in
- s`I`gn up

It was a conscious design decision that all of these are on or near the
home row, for additional comfort.

I would love a second pair of eyes on this to make sure I'm not crazy.