### PR TITLE
[WIP] Added start date to Tasks

### DIFF
--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -38,7 +38,8 @@ $(function() {
 
     $(document).on("page:change", function() {
         $("#archive-toggle").click(toggleArchived);
-	$("#task_datetimepicker").datetimepicker({ format: "L" });
+	$("#task_start_datetimepicker").datetimepicker({ format: "L" });
+	$("#task_due_datetimepicker").datetimepicker({ format: "L" });
 	setupCompleteHandlers();
         loadSelect2();
     });

--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -24,23 +24,23 @@ $(function() {
     }
 
     var setupCompleteHandlers = function() {
-	$(".task-table input[type=checkbox]").change(function(event) {
-	    var id = event.target.id.substr(5);
-	    var target = $(event.target);
+        $(".task-table input[type=checkbox]").change(function(event) {
+            var id = event.target.id.substr(5);
+            var target = $(event.target);
 
-	    if (target.prop("checked")) {
-		window.location = "/tasks/" + id + "/archive"
-	    } else {
-		window.location = "/tasks/" + id + "/unarchive"
-	    }
-	});
+            if (target.prop("checked")) {
+                window.location = "/tasks/" + id + "/archive"
+            } else {
+                window.location = "/tasks/" + id + "/unarchive"
+            }
+        });
     }
 
     $(document).on("page:change", function() {
         $("#archive-toggle").click(toggleArchived);
-	$("#task_start_datetimepicker").datetimepicker({ format: "L" });
-	$("#task_due_datetimepicker").datetimepicker({ format: "L" });
-	setupCompleteHandlers();
+        $("#task_start_datetimepicker").datetimepicker({ format: "L" });
+        $("#task_due_datetimepicker").datetimepicker({ format: "L" });
+        setupCompleteHandlers();
         loadSelect2();
     });
 });

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -53,6 +53,7 @@ class TasksController < ApplicationController
   end
 
   private
+
     def set_task
       @task = Task.find(params[:id])
     end
@@ -70,11 +71,17 @@ class TasksController < ApplicationController
       new_params = params.require(:task).permit(:task_name, :estimate,
                                                 :archived_at, :priority,
                                                 :user_id, :due_date,
-                                                tag_ids: [])
+                                                :start_date, tag_ids: [])
       new_params[:user_id] = current_user.id unless current_user.admin?
-      unless new_params[:due_date].blank?
+
+      if new_params[:due_date].present?
         new_params[:due_date] = Date.american_date(new_params[:due_date])
       end
+
+      if new_params[:start_date].present?
+        new_params[:start_date] = Date.american_date(new_params[:start_date])
+      end
+
       new_params
     end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -64,6 +64,7 @@ class Task < ActiveRecord::Base
 
   def due_today
     return 0 unless estimate && due_date
+    return 0 if start_date && start_date > Date.today
 
     work_left = estimate - done_before_today
 

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -33,8 +33,17 @@
       <%= f.number_field :estimate, class: "form-control" %>
     </div>
     <div class="form-group col-md-4">
+	<%= f.label :start_date %>
+	<div class='input-group date' id='task_start_datetimepicker'>
+	    <%= f.text_field :start_date, value: (@task.start_date.try(:american_date) || Date.today.american_date), class: "form-control" %>
+	    <span class="input-group-addon">
+		<span class="glyphicon glyphicon-calendar"></span>
+	    </span>
+	</div>
+    </div>
+    <div class="form-group col-md-4">
       <%= f.label :due_date %><br>
-      <div class='input-group date' id='task_datetimepicker'>
+      <div class='input-group date' id='task_due_datetimepicker'>
 	<%= f.text_field :due_date, value: @task.due_date.try(:american_date), class: "form-control" %>
 	<span class="input-group-addon">
 	  <span class="glyphicon glyphicon-calendar"></span>

--- a/db/migrate/20161116200213_add_start_date_to_tasks.rb
+++ b/db/migrate/20161116200213_add_start_date_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStartDateToTasks < ActiveRecord::Migration
+  def change
+    add_column :tasks, :start_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160829215454) do
+ActiveRecord::Schema.define(version: 20161116200213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20160829215454) do
     t.integer  "user_id"
     t.datetime "archived_at"
     t.date     "due_date"
+    t.date     "start_date"
   end
 
   create_table "time_entries", force: :cascade do |t|

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -5,7 +5,7 @@ class TasksControllerTest < ActionController::TestCase
     @user = users(:one)
     sign_in @user
 
-    @task = tasks(:one)
+    @task = tasks(:unarchived_full)
 
     @params = {
       task_name: "Foobar",

--- a/test/controllers/time_entries_controller_test.rb
+++ b/test/controllers/time_entries_controller_test.rb
@@ -16,7 +16,7 @@ class TimeEntriesControllerTest < ActionController::TestCase
       duration: 30,
       note: "note",
       start_time: Time.new(2016, 8, 28, 10, 30).american_date,
-      task_id: tasks(:one).id,
+      task_id: tasks(:unarchived_full).id,
       user_id: users(:one).id
     }
 

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -1,25 +1,46 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
+unarchived_full:
+  user: one
+  task_name: Homework 1000
+  priority: 4
+  estimate: 60
+  start_date: <%= Date.today %>
+  due_date: <%= Date.today + 1 %>
+
+unarchived_no_start:
   user: one
   task_name: Task One
   priority: 4
   due_date: <%= Date.today + 1 %>
   estimate: 60
 
-two:
+unarchived_no_start_no_estimate:
+  user: two
+  task_name: Task Three
+  priority: 2
+  due_date: <%= Date.today + 1 %>
+
+unarchived_empty:
+  user: two
+  task_name: 1234
+
+archived_full:
+  user: one
+  task_name: Archived Full
+  priority: 5
+  estimate: 54
+  start_date: <%= Date.today %>
+  due_date: <%= Date.today + 1 %>
+  archived_at: <%= Date.today %>
+
+archived_no_start_no_estimate_no_priority:
+  user: two
+  task_name: Task Four
+  due_date: <%= Date.today + 1 %>
+  archived_at: <%= DateTime.now - 1.days %>
+
+archived_empty:
   user: one
   task_name: Task Two
   archived_at: <%= DateTime.now - 1.days %>
-
-three:
-  user: two
-  priority: 2
-  task_name: Task Three
-  due_date: <%= Date.today + 1 %>
-
-four:
-  user: two
-  task_name: Task Four
-  archived_at: <%= DateTime.now - 1.days %>
-  due_date: <%= Date.today + 1 %>

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,23 +1,4 @@
 require 'test_helper'
 
 class TagTest < ActiveSupport::TestCase
-  setup do
-    @tag = tags(:one)
-    @task = tasks(:one)
-  end
-
-  test "does not orphan taggings" do
-    before_taggings = Tagging.count
-
-    @tag.save!
-    @tag.tasks << @task
-
-    # Assert tagging was created
-    assert_equal(Tagging.count, before_taggings + 1)
-
-    @tag.destroy
-
-    # Assert tagging was destroyed
-    assert_equal(Tagging.count, before_taggings)
-  end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TaskTest < ActiveSupport::TestCase
   setup do
-    @task = tasks(:one)
+    @task = tasks(:unarchived_full)
     @tag = tags(:one)
     @time_entry = time_entries(:one)
   end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -82,4 +82,9 @@ class TaskTest < ActiveSupport::TestCase
     @task.update!(estimate: nil, due_date: Date.today)
     assert_equal(@task.due_today, 0)
   end
+
+  test 'due today not started' do
+    @task.update!(start_date: Date.today + 1)
+    assert_equal(@task.due_today, 0)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,7 +4,7 @@ class UserTest < ActiveSupport::TestCase
   setup do
     @user = users(:one)
     @tag = tags(:one)
-    @task = tasks(:one)
+    @task = tasks(:unarchived_full)
     @time_entry = time_entries(:one)
   end
 


### PR DESCRIPTION
The motivation here is to have a way to add tasks that do not require immediate work (e.g. due in two weeks, estimate is 2 minutes / day). There are some interesting details about the implementation here that require scrutiny:
- Start dates are not required, but have a default (today)
- Said default exists only in the UI, but is not enforced by the database

### Alternate implementation
Instead of changing the "New Task" screen, there is a button on the Tasks page labelled something like "Procrastinate." Pressing this button will set the start date to the subsequent day. This, despite it's name, should actually deincentivize procrastination, since procrastinating entails pushing the "Procrastinate" button every day.

I'd absolutely adore feedback :sparkles:

Closes #98 