### PR TITLE
Added Tag labels for index views

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -153,3 +153,7 @@ form.button_to {
 .cursor-tooltip {
 	cursor: pointer;
 }
+
+.label {
+  margin-right: 5px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,6 @@ module ApplicationHelper
     tag_spans = task.tags.map do |tag|
       content_tag(:span, tag.name, class: ['label', 'label-info'])
     end
-    task_div + tag_spans.reduce(:+)
+    task_div + tag_spans.join.html_safe
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,12 @@ module ApplicationHelper
     minutes = minutes - (hours * 60)
     "#{format('%02d', hours)}:#{format('%02d', minutes)}"
   end
+
+  def task_with_tag_labels(task)
+    task_div = content_tag(:div, task.task_name)
+    tag_spans = task.tags.map do |tag|
+      content_tag(:span, tag.name, class: ['label', 'label-info'])
+    end
+    task_div + tag_spans.reduce(:+)
+  end
 end

--- a/app/views/tasks/_archived_task_table.html.erb
+++ b/app/views/tasks/_archived_task_table.html.erb
@@ -23,7 +23,7 @@
             <input type="checkbox" id="task-<%= task.id %>" />
           <% end %>
         </td>
-        <td><%= task.explicit_name %></td>
+        <td><%= task_with_tag_labels(task) %></td>
 	<td><%= duration_display(task.time_spent) %></td>
         <% if current_user.admin? %>
           <td><%= task.user.username %></td>

--- a/app/views/tasks/_task_table.html.erb
+++ b/app/views/tasks/_task_table.html.erb
@@ -25,7 +25,7 @@
             <input type="checkbox" id="task-<%= task.id %>" />
           <% end %>
         </td>
-        <td><%= task.explicit_name %></td>
+        <td><%= task_with_tag_labels(task) %></td>
         <% if task.time_remaining_today > 0 %>
           <td><%= duration_display(task.time_remaining_today.round) %></td>
         <% else %>

--- a/app/views/time_entries/_time_entries.html.erb
+++ b/app/views/time_entries/_time_entries.html.erb
@@ -3,7 +3,7 @@
       <% time_entries.each do |entry| %>
         <tr>
           <td><%= entry.start_time.strftime("%H:%M") %></td>
-          <td><b><%= entry.task.explicit_name %></b></td>
+          <td><b><%= task_with_tag_labels(entry.task) %></b></td>
           <td><div class="only-desktop"><%= entry.goal %></div></td>
           <td><div class="only-desktop"><%= entry.result %></div></td>
           <td>


### PR DESCRIPTION
On the Tasks#index page:
<img width="500" alt="screen shot 2016-12-01 at 15 47 09" src="https://cloud.githubusercontent.com/assets/2058614/20812167/94ff7086-b7de-11e6-9ff3-a5a170532914.png">
On TimeEntries#index:
<img width="383" alt="screen shot 2016-12-01 at 15 53 18" src="https://cloud.githubusercontent.com/assets/2058614/20812184/a2ff280c-b7de-11e6-935c-eb40c5c31909.png">
Regrettably, `<option>` tags are not allowed to contain HTML, so they are still left looking the same:
<img width="512" alt="screen shot 2016-12-01 at 15 52 53" src="https://cloud.githubusercontent.com/assets/2058614/20812209/bc827086-b7de-11e6-8713-8fc72e2c22ea.png">

I'm fairly satisfied with this, so unless anyone raises serious concerns within the next hour or so, I'll be merging this.

Closes #107 