### PR TITLE
Show running time entries on today's page

### DIFF
--- a/app/assets/javascripts/time_entries.js
+++ b/app/assets/javascripts/time_entries.js
@@ -26,11 +26,17 @@ $(function() {
 
 (function poll(){
   setTimeout(function() {
-    var filterDate = $('.js-update-entries').data('filterDate')
+    var filterDate = $('.js-update-entries').data('filterDate');
 
     if (filterDate) {
-      $.ajax({ url: '/time_entries/updates_all_time_entries?date=' + filterDate, complete: poll, timeout: 60000 });
+      $.get({
+        url: '/time_entries/updates_all_time_entries',
+        data: { date: filterDate },
+        complete: function(data) {
+          $('.js-update-entries').html(data.responseText);
+          poll();
+        },
+        timeout: 60000 });
     }
   }, 60000);
 })();
-

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -147,17 +147,18 @@ form.button_to {
   margin-bottom: 20px;
 }
 
-.time-container {
-  margin-top: .5em;
-  font-size: medium;
-  //float: right;
-  text-align: right;
-}
-
 .cursor-tooltip {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 .label {
   margin-right: 5px;
+}
+
+.panel-heading {
+  font-weight: bold;
+}
+
+.panel.overrun .panel-heading {
+  background: lighten($red, 40%);
 }

--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -7,7 +7,9 @@ class TimeEntriesController < ApplicationController
   before_action :set_tag, only: [:report]
   before_action :set_date, only: [:index, :updates_all_time_entries]
   before_action :set_time_entries, only: [:index, :updates_all_time_entries]
-  before_action :set_overrun_entries, only: [:index], if: -> { @date == Date.today }
+  before_action :set_overrun_entries,
+                only: [:index, :updates_all_time_entries],
+                if: -> { @date == Date.today }
   before_action -> { ensure_ownership(@tag) }, only: [:report]
   respond_to :html, :js
 
@@ -86,6 +88,7 @@ class TimeEntriesController < ApplicationController
   end
 
   def updates_all_time_entries
+    render action: 'updates_all_time_entries', layout: nil
   end
 
   private

--- a/app/views/time_entries/_entries_table.html.erb
+++ b/app/views/time_entries/_entries_table.html.erb
@@ -1,18 +1,16 @@
-<table class="table">
+<div class="panel panel-default <%= 'overrun' if overrun %>" >
+  <div class="panel-heading"><%= std_date(date) %></div>
+  <table class="table">
     <tbody>
-      <% time_entries.each do |entry| %>
+      <% entries.each do |entry| %>
         <tr>
           <td><%= entry.start_time.strftime("%H:%M") %></td>
           <td><b><%= task_with_tag_labels(entry.task) %></b></td>
           <td><div class="only-desktop"><%= entry.goal %></div></td>
           <td><div class="only-desktop"><%= entry.result %></div></td>
-          <td>
-            <%= duration_display(entry.real_duration) %>
-          </td>
+          <td><%= duration_display(entry.real_duration) %></td>
           <% if @admin %>
-            <td>
-              <%= entry.user.username %>
-            </td>
+            <td><%= entry.user.username %></td>
           <% end %>
           <td class="col-md-3 btn-col">
             <div class="btn-container">
@@ -25,10 +23,12 @@
           </td>
         </tr>
       <% end %>
-      <tr>
-        <td colspan='4'><b>Total</b></td>
-        <td colspan='5'><%= duration_display(total) %></td>
-      </tr>
+      <% if total.present? %>
+        <tr>
+          <td colspan='4'><b>Total</b></td>
+          <td colspan='5'><%= duration_display(total) %></td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
-
+</div>

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -1,7 +1,6 @@
 <h1 class="time-title">
   Time Entries <%= link_to '+', new_time_entry_path, data: { keybinding: 'n' } %>
-  <div class="time-container">
-    <time style="padding: 15px; font-weight: bold"><%= std_date(@date) %></time>
+  <div class="pull-right">
     <br class="visible-sm visible-xs">
     <div class="btn-group time-nav">
       <%= link_to "<<", time_entries_path(date: @date - 1.day), class: 'btn btn-default' %>
@@ -27,5 +26,10 @@
 </div>
 
 <div class="col-md-10 js-update-entries" data-filter-date="<%= @date %>">
-  <%= render 'time_entries', time_entries: @time_entries, total: @total %>
+  <% if @overrun_entries.present? %>
+    <% @overrun_entries.each do |date, entries| %>
+      <%= render 'entries_table', entries: entries, total: nil, date: date, overrun: true %>
+    <% end %>
+  <% end %>
+  <%= render 'entries_table', entries: @time_entries, total: @total, date: @date, overrun: false %>
 </div>

--- a/app/views/time_entries/updates_all_time_entries.html.erb
+++ b/app/views/time_entries/updates_all_time_entries.html.erb
@@ -1,0 +1,6 @@
+<% if @overrun_entries.present? %>
+  <% @overrun_entries.each do |date, entries| %>
+    <%= render 'entries_table', entries: entries, total: nil, date: date, overrun: true %>
+  <% end %>
+<% end %>
+<%= render 'entries_table', entries: @time_entries, total: @total, date: @date, overrun: false %>

--- a/app/views/time_entries/updates_all_time_entries.js.erb
+++ b/app/views/time_entries/updates_all_time_entries.js.erb
@@ -1,3 +1,0 @@
-<% if @time_entries.present? %>
-  $('.js-update-entries').html("<%= j render 'time_entries', time_entries: @time_entries, total: @total %>");
-<% end %>


### PR DESCRIPTION
People (myself included) sometimes forget to stop timers. When a day passes and these timers are forgotten, this can lead to things getting really messed up (like time remaining, percent of estimate done, etc). This PR will make it so that all running timers are included on every time entry page so that they will not be forgotten about.

This is a first pass, and is subject to change.

Closes #82 