### PR TITLE
Stop polling if 'filterDate' is undefined

### DIFF
--- a/app/assets/javascripts/time_entries.js
+++ b/app/assets/javascripts/time_entries.js
@@ -28,7 +28,9 @@ $(function() {
   setTimeout(function() {
     var filterDate = $('.js-update-entries').data('filterDate')
 
-    $.ajax({ url: '/time_entries/updates_all_time_entries?date=' + filterDate, complete: poll, timeout: 60000 });
+    if (filterDate) {
+      $.ajax({ url: '/time_entries/updates_all_time_entries?date=' + filterDate, complete: poll, timeout: 60000 });
+    }
   }, 60000);
 })();
 


### PR DESCRIPTION
This script is only intended to be run on the TimeEntries#index page. Unfortunately, it runs on every page, which results in a lot of queries to the server with the GET parameter `date=undefined`. By checking that `filterDate` is truthy (i.e. not `undefined` or some other not-date things), we should be reasonably confident that the date being sent to the server is probably actually a date.