### PR TITLE
TimeEntry tests

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,9 +6,9 @@ class Task < ApplicationRecord
 
   validates_presence_of :user_id, :task_name
 
-  scope :order_last_touched, -> do
+  scope :order_last_touched, lambda {
     includes(:time_entries).order('time_entries.start_time DESC')
-  end
+  }
   scope :active, -> { where(archived_at: nil) }
   scope :archived, -> { where.not(archived_at: nil) }
 
@@ -27,9 +27,7 @@ class Task < ApplicationRecord
   end
 
   def percent_time_used
-    if self.estimate.nil? || self.estimate.zero?
-      return 0
-    end
+    return 0 if self.estimate.nil? || self.estimate.zero?
 
     (self.time_spent.to_f / self.estimate) * 100
   end

--- a/test/fixtures/time_entries.yml
+++ b/test/fixtures/time_entries.yml
@@ -10,6 +10,5 @@ one:
 two:
   user_id: two
   task_id: three
-  duration: 20
   start_time: 2015-01-08 09:52:58
   note: Other text

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -7,7 +7,7 @@ class TaskTest < ActiveSupport::TestCase
     @time_entry = time_entries(:one)
   end
 
-  test "does not orphan taggings" do
+  test 'does not orphan taggings' do
     before_taggings = Tagging.count
 
     @task.save!
@@ -22,7 +22,7 @@ class TaskTest < ActiveSupport::TestCase
     assert_equal(Tagging.count, before_taggings)
   end
 
-  test "does not orphan time entries" do
+  test 'does not orphan time entries' do
     before_count = TimeEntry.count
 
     @task.save!
@@ -36,22 +36,22 @@ class TaskTest < ActiveSupport::TestCase
     assert_equal(TimeEntry.count, before_count - 1)
   end
 
-  test "time remaining base case" do
+  test 'time remaining base case' do
     @task.update(due_date: Date.today + 1.days)
     assert_equal(60, @task.time_remaining_today)
   end
 
-  test "time remaining handles zero days case" do
+  test 'time remaining handles zero days case' do
     @task.update(due_date: Date.today)
     assert_equal(60, @task.time_remaining_today)
   end
 
-  test "time remaining handles negative days case" do
+  test 'time remaining handles negative days case' do
     @task.update(due_date: Date.today - 1.days)
     assert_equal(60, @task.time_remaining_today)
   end
 
-  test "time remaining handles timezones at least sort of" do
+  test 'time remaining handles timezones at least sort of' do
     initial_time_remaining = @task.time_remaining_today
     @task.time_entries.create!(user: users(:one), duration: 30, start_time: Date.today.to_time + 22.hours)
     assert_equal(initial_time_remaining - 30, @task.time_remaining_today)

--- a/test/models/time_entry_test.rb
+++ b/test/models/time_entry_test.rb
@@ -1,7 +1,15 @@
 require 'test_helper'
 
 class TimeEntryTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @entry = time_entries(:one)
+    @entry_two = time_entries(:two)
+  end
+
+  test 'real_duration works for running entries' do
+    @entry_two.update!(start_time: Time.new(2018, 3, 17, 20), running: true)
+    travel_to Time.new(2018, 3, 17, 21) do
+      assert_equal 60, @entry_two.real_duration
+    end
+  end
 end


### PR DESCRIPTION
The coverage showed that there were two methods not sufficiently covered in all of the models: `TimeEntry#real_duration` and `TimeEntry.to_csv`. The latter proved quite difficult to test, and needs rewriting anyways. This PR adds a test for the former.

Fixes #3 