### PR TITLE
[WIP] Add an Analytics page

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,0 +1,3 @@
+class AnalyticsController < ApplicationController
+  def index; end
+end

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -1,0 +1,7 @@
+<h1>Analytics</h1>
+
+<div class="col-md-2">
+  <div class="row only-desktop">
+    <%= button_to "Export CSV", export_time_entries_path(format: :csv), method: :get, class: "btn btn-default col-md-12" %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
             <li><%= link_to "Tags", tags_path, data: { keybinding: 'a' } %></li>
             <li><%= link_to "Tasks", tasks_path, data: { keybinding: 's' } %></li>
             <li><%= link_to "Time Entries", time_entries_path, data: { keybinding: 'e' } %></li>
+            <li><%= link_to "Analytics", analytics_path, data: { keybinding: 'l' } %></li>
           </ul>
         <% end %>
 

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -10,22 +10,7 @@
   </div>
 </h1>
 
-<div class="col-md-2">
-  <div class="row only-desktop">
-    <%= button_to "Export CSV", export_time_entries_path(format: :csv), method: :get, class: "btn btn-default col-md-12" %>
-  </div>
-  <br>
-  <% if @tags.any? %>
-    <div class="row only-desktop">
-      <%= form_tag '/time_entries/report', method: :get do %>
-        <%= select_tag "tag_id", options_from_collection_for_select(@tags, "id", "name"), class: "form-control" %>
-        <%= submit_tag "Generate Report", class: "btn btn-default form-control" %>
-      <% end %>
-    </div>
-  <% end %>
-</div>
-
-<div class="col-md-10 js-update-entries" data-filter-date="<%= @date %>">
+<div class="js-update-entries" data-filter-date="<%= @date %>">
   <% if @overrun_entries.present? %>
     <% @overrun_entries.each do |date, entries| %>
       <%= render 'entries_table', entries: entries, total: nil, date: date, overrun: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,8 @@ Rails.application.routes.draw do
       get 'unarchive'
     end
   end
+
   resources :tags, except: :show
+
+  get 'analytics', to: 'analytics#index'
 end

--- a/test/controllers/analytics_controller_test.rb
+++ b/test/controllers/analytics_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AnalyticsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Ideally, the analytics page will provide useful statistics for the set of time entries (or, perhaps less granularly, tasks) that the user selects. Speaking of which, there should also be an intuitive interface for the user to select the time entries or tasks they want to include in the report.

Closes #60 