### PR TITLE
Rename archived to completed

### DIFF
--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -7,20 +7,20 @@ $(function() {
         $("#task_tag_ids").select2();
     }
 
-    var archivedShown = false;
-    var toggleArchived = function(e) {
+    var completedShown = false;
+    var toggleCompleted = function(e) {
         var archiveToggle = e.currentTarget;
-        var archived = $("#archived-tasks");
+        var completed = $("#completed-tasks");
 
-        if (archivedShown) {
-            $(archived).hide();
-            $(archiveToggle).html("Show archived");
+        if (completedShown) {
+            $(completed).hide();
+            $(archiveToggle).html("Show completed");
         } else {
-            $(archived).show();
-            $(archiveToggle).html("Hide archived");
+            $(completed).show();
+            $(archiveToggle).html("Hide completed");
         }
 
-        archivedShown = !archivedShown;
+        completedShown = !completedShown;
     }
 
     var setupCompleteHandlers = function() {
@@ -37,7 +37,7 @@ $(function() {
     }
 
     $(document).on("turbolinks:load", function() {
-        $("#archive-toggle").click(toggleArchived);
+        $("#archive-toggle").click(toggleCompleted);
         $("#task_start_datetimepicker").datetimepicker({ format: "L" });
         $("#task_due_datetimepicker").datetimepicker({ format: "L" });
         setupCompleteHandlers();

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -92,12 +92,12 @@ $red:    red;
   padding: 10px;
 }
 
-// Hide archived tasks by default
+// Hide completed tasks by default
 #archive-toggle {
   cursor: pointer;
 }
 
-#archived-tasks {
+#completed-tasks {
   display: none;
 }
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,15 +10,14 @@ class TasksController < ApplicationController
     @tasks = @tasks.where(user: current_user) unless current_user.admin?
 
     @active = @tasks.active.order_todo
-    @archived = @tasks.archived.order(archived_at: :desc)
+    @completed = @tasks.completed.order(completed_at: :desc)
   end
 
   def new
     @task = Task.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @task = Task.new(task_params)
@@ -38,12 +37,12 @@ class TasksController < ApplicationController
   end
 
   def archive
-    @task.update(archived_at: DateTime.now)
+    @task.update(completed_at: DateTime.now)
     redirect_to tasks_path
   end
 
   def unarchive
-    @task.update(archived_at: nil)
+    @task.update(completed_at: nil)
     redirect_to tasks_path
   end
 
@@ -69,7 +68,7 @@ class TasksController < ApplicationController
 
     def task_params
       new_params = params.require(:task).permit(:task_name, :estimate,
-                                                :archived_at, :priority,
+                                                :completed_at, :priority,
                                                 :user_id, :due_date,
                                                 :start_date, tag_ids: [])
       format_params(new_params)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,8 +9,8 @@ class Task < ApplicationRecord
   scope :order_last_touched, lambda {
     includes(:time_entries).order('time_entries.start_time DESC')
   }
-  scope :active, -> { where(archived_at: nil) }
-  scope :archived, -> { where.not(archived_at: nil) }
+  scope :active, -> { where(completed_at: nil) }
+  scope :completed, -> { where.not(completed_at: nil) }
 
   def self.order_todo
     tasks = all.sort_by { |x| -x.due_today }
@@ -36,8 +36,8 @@ class Task < ApplicationRecord
     "#{self.task_name} - #{self.tags.pluck(:name).join(", ")}"
   end
 
-  def archived?
-    self.archived_at.present?
+  def completed?
+    self.completed_at.present?
   end
 
   def days_left
@@ -45,7 +45,7 @@ class Task < ApplicationRecord
   end
 
   def overdue?
-    !archived? && days_left.present? && days_left < 0
+    !completed? && days_left.present? && days_left < 0
   end
 
   def time_remaining_today

--- a/app/views/tasks/_completed_task_table.html.erb
+++ b/app/views/tasks/_completed_task_table.html.erb
@@ -17,7 +17,7 @@
       <tr class="<%= "priority#{task.priority} overdue" if task.overdue? %>">
         <td class="swatch priority<%= task.priority %>"></td>
         <td>
-          <% if task.archived? %>
+          <% if task.completed? %>
             <input type="checkbox" id="task-<%= task.id %>" checked />
           <% else %>
             <input type="checkbox" id="task-<%= task.id %>" />

--- a/app/views/tasks/_task_table.html.erb
+++ b/app/views/tasks/_task_table.html.erb
@@ -19,7 +19,7 @@
       <tr class="<%= "priority#{task.priority} overdue" if task.overdue? %>">
         <td class="swatch priority<%= task.priority %>"></td>
         <td>
-          <% if task.archived? %>
+          <% if task.completed? %>
             <input type="checkbox" id="task-<%= task.id %>" checked />
           <% else %>
             <input type="checkbox" id="task-<%= task.id %>" />

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,10 +1,10 @@
 <h1>Tasks <%= link_to '+', new_task_path, data: { keybinding: 'n' } %></h1>
 <%= render 'task_table', tasks: @active %>
 
-<% if @archived.any? %>
-  <a id="archive-toggle">Show archived</a>
-  <div id="archived-tasks">
-    <h2>Archived</h2>
-    <%= render 'archived_task_table', tasks: @archived  %>
+<% if @completed.any? %>
+  <a id="archive-toggle">Show completed</a>
+  <div id="completed-tasks">
+    <h2>Completed</h2>
+    <%= render 'completed_task_table', tasks: @completed  %>
   </div>
 <% end %>

--- a/db/migrate/20180331020228_rename_archived_completed.rb
+++ b/db/migrate/20180331020228_rename_archived_completed.rb
@@ -1,0 +1,5 @@
+class RenameArchivedCompleted < ActiveRecord::Migration[5.0]
+  def change
+    rename_column(:tasks, :archived_at, :completed_at)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116200213) do
+ActiveRecord::Schema.define(version: 20180331020228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,12 +33,12 @@ ActiveRecord::Schema.define(version: 20161116200213) do
 
   create_table "tasks", force: :cascade do |t|
     t.text     "task_name"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
     t.integer  "estimate"
-    t.integer  "priority",    default: 1, null: false
+    t.integer  "priority",     default: 1, null: false
     t.integer  "user_id"
-    t.datetime "archived_at"
+    t.datetime "completed_at"
     t.date     "due_date"
     t.date     "start_date"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,13 +41,13 @@ j3rn_tasks = j3rn_tags.first.tasks.create!([
     task_name: 'Homework #3',
     priority: 3,
     user_id: j3rn.id,
-    archived_at: DateTime.now,
+    completed_at: DateTime.now,
   },
   {
     task_name: 'Homework #2',
     priority: 5,
     user_id: j3rn.id,
-    archived_at: DateTime.now - 3.days,
+    completed_at: DateTime.now - 3.days,
     due_date: DateTime.now - 3.day
   }
 ])
@@ -69,12 +69,12 @@ test_tags.last.tasks.create!([
   },
   { task_name: 'Testing some things',
     user_id: test.id,
-    archived_at: DateTime.now,
+    completed_at: DateTime.now,
     due_date: Date.today
   },
   {
     task_name: 'Testing other things',
     user_id: test.id,
-    archived_at: DateTime.now - 1.days
+    completed_at: DateTime.now - 1.days
   }
 ])

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -5,7 +5,7 @@ class TasksControllerTest < ActionController::TestCase
     @user = users(:one)
     sign_in @user
 
-    @task = tasks(:unarchived_full)
+    @task = tasks(:uncompleted_full)
 
     @params = {
       task_name: 'Foobar',

--- a/test/controllers/time_entries_controller_test.rb
+++ b/test/controllers/time_entries_controller_test.rb
@@ -16,7 +16,7 @@ class TimeEntriesControllerTest < ActionController::TestCase
       duration: 30,
       note: 'note',
       start_time: Time.new(2016, 8, 28, 10, 30).american_date,
-      task_id: tasks(:unarchived_full).id,
+      task_id: tasks(:uncompleted_full).id,
       user_id: users(:one).id
     }
 

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -1,6 +1,6 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-unarchived_full:
+uncompleted_full:
   user: one
   task_name: Homework 1000
   priority: 4
@@ -8,39 +8,39 @@ unarchived_full:
   start_date: <%= Date.today %>
   due_date: <%= Date.today + 1 %>
 
-unarchived_no_start:
+uncompleted_no_start:
   user: one
   task_name: Task One
   priority: 4
   due_date: <%= Date.today + 1 %>
   estimate: 60
 
-unarchived_no_start_no_estimate:
+uncompleted_no_start_no_estimate:
   user: two
   task_name: Task Three
   priority: 2
   due_date: <%= Date.today + 1 %>
 
-unarchived_empty:
+uncompleted_empty:
   user: two
   task_name: 1234
 
-archived_full:
+completed_full:
   user: one
-  task_name: Archived Full
+  task_name: Completed Full
   priority: 5
   estimate: 54
   start_date: <%= Date.today %>
   due_date: <%= Date.today + 1 %>
-  archived_at: <%= Date.today %>
+  completed_at: <%= Date.today %>
 
-archived_no_start_no_estimate_no_priority:
+completed_no_start_no_estimate_no_priority:
   user: two
   task_name: Task Four
   due_date: <%= Date.today + 1 %>
-  archived_at: <%= DateTime.now - 1.days %>
+  completed_at: <%= DateTime.now - 1.days %>
 
-archived_empty:
+completed_empty:
   user: one
   task_name: Task Two
-  archived_at: <%= DateTime.now - 1.days %>
+  completed_at: <%= DateTime.now - 1.days %>

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TaskTest < ActiveSupport::TestCase
   setup do
-    @task = tasks(:unarchived_full)
+    @task = tasks(:uncompleted_full)
     @tag = tags(:one)
     @time_entry = time_entries(:one)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,7 +4,7 @@ class UserTest < ActiveSupport::TestCase
   setup do
     @user = users(:one)
     @tag = tags(:one)
-    @task = tasks(:unarchived_full)
+    @task = tasks(:uncompleted_full)
     @time_entry = time_entries(:one)
   end
 


### PR DESCRIPTION
Which is funny, in retrospect, because org-mode (now a major influence
on development) uses the term "archived" instead of "completed." In
any event, this was a massive find-and-replace operation. I'll be
lucky if nothing major breaks.

Fixes #115 