### PR TITLE
Rename "archive" to "complete"

### DIFF
--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -9,15 +9,15 @@ $(function() {
 
     var completedShown = false;
     var toggleCompleted = function(e) {
-        var archiveToggle = e.currentTarget;
+        var completeToggle = e.currentTarget;
         var completed = $("#completed-tasks");
 
         if (completedShown) {
             $(completed).hide();
-            $(archiveToggle).html("Show completed");
+            $(completeToggle).html("Show completed");
         } else {
             $(completed).show();
-            $(archiveToggle).html("Hide completed");
+            $(completeToggle).html("Hide completed");
         }
 
         completedShown = !completedShown;
@@ -29,15 +29,15 @@ $(function() {
             var target = $(event.target);
 
             if (target.prop("checked")) {
-                window.location = "/tasks/" + id + "/archive"
+                window.location = "/tasks/" + id + "/complete"
             } else {
-                window.location = "/tasks/" + id + "/unarchive"
+                window.location = "/tasks/" + id + "/uncomplete"
             }
         });
     }
 
     $(document).on("turbolinks:load", function() {
-        $("#archive-toggle").click(toggleCompleted);
+        $("#complete-toggle").click(toggleCompleted);
         $("#task_start_datetimepicker").datetimepicker({ format: "L" });
         $("#task_due_datetimepicker").datetimepicker({ format: "L" });
         setupCompleteHandlers();

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -93,7 +93,7 @@ $red:    red;
 }
 
 // Hide completed tasks by default
-#archive-toggle {
+#complete-toggle {
   cursor: pointer;
 }
 
@@ -132,12 +132,12 @@ form.button_to {
   @extend .btn-danger;
 }
 
-.btn-archive {
+.btn-complete {
   @include custom-button;
   @extend .btn-default;
 }
 
-.btn-unarchive {
+.btn-uncomplete {
   @include custom-button;
   @extend .btn-default;
 }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,8 +1,8 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: [:edit, :update, :destroy, :archive,
-                                  :unarchive]
-  before_action :set_tags, except: [:archive, :unarchive, :destroy]
-  before_action :set_users, except: [:archive, :unarchive, :destroy]
+  before_action :set_task, only: [:edit, :update, :destroy, :complete,
+                                  :uncomplete]
+  before_action :set_tags, except: [:complete, :uncomplete, :destroy]
+  before_action :set_users, except: [:complete, :uncomplete, :destroy]
   before_action -> { ensure_ownership(@task) }, only: [:edit, :update, :destroy]
 
   def index
@@ -37,12 +37,12 @@ class TasksController < ApplicationController
     end
   end
 
-  def archive
+  def complete
     @task.update(completed_at: Time.now)
     redirect_to tasks_path
   end
 
-  def unarchive
+  def uncomplete
     @task.update(completed_at: nil)
     redirect_to tasks_path
   end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -3,11 +3,11 @@ module TasksHelper
     days || "???"
   end
 
-  def archive_btn(path)
-    link_to "\ue117", path, class: "btn-archive"
+  def complete_btn(path)
+    link_to "\ue117", path, class: "btn-complete"
   end
 
-  def unarchive_btn(path)
-    link_to "\ue118", path, class: "btn-unarchive"
+  def uncomplete_btn(path)
+    link_to "\ue118", path, class: "btn-uncomplete"
   end
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,7 +2,7 @@
 <%= render 'task_table', tasks: @active %>
 
 <% if @completed.any? %>
-  <a id="archive-toggle">Show completed</a>
+  <a id="complete-toggle">Show completed</a>
   <div id="completed-tasks">
     <h2>Completed</h2>
     <%= render 'completed_task_table', tasks: @completed  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
 
   resources :tasks, except: :show do
     member do
-      get "archive"
-      get "unarchive"
+      get "complete"
+      get "uncomplete"
     end
   end
   resources :tags, except: :show


### PR DESCRIPTION
Evidently, in the previous PR, I missed instances of "archive" in
favor of instances of "archived."