### PR TITLE
Make users confirm their email addresses

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+  # Others available are:
+  # :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable, :recoverable,
+         :rememberable, :trackable, :validatable, :confirmable
 
   has_many :time_entries, dependent: :destroy
   has_many :tags, dependent: :destroy

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: "timesheet.j3rn.com" }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -76,4 +76,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: "staging.timesheet.j3rn.com" }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,10 +10,10 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "noreply@timesheet.j3rn.com"
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/db/migrate/20180331033131_add_confirmable_to_users.rb
+++ b/db/migrate/20180331033131_add_confirmable_to_users.rb
@@ -1,0 +1,16 @@
+class AddConfirmableToUsers < ActiveRecord::Migration[5.0]
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+
+    add_index :users, :confirmation_token, unique: true
+
+    User.all.update_all(confirmed_at: Time.now)
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at, :unconfirmed_email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180331020228) do
+ActiveRecord::Schema.define(version: 20180331033131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,11 @@ ActiveRecord::Schema.define(version: 20180331020228) do
     t.text     "username"
     t.text     "display_name"
     t.boolean  "admin",                  default: false
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -9,15 +9,18 @@ one:
   username: J3RN
   display_name: J3RN
   encrypted_password: blargblarg
+  confirmed_at: 2018-01-01
 
 two:
   email: example@example.com
   username: Test
   display_name: Test
   encrypted_password: foobarbar
+  confirmed_at: 2018-01-10
 
 admin:
   email: admin@example.com
   username: admin
   display_name: admin
   encrypted_password: admin
+  confirmed_at: 2018-10-01


### PR DESCRIPTION
Taking a look through the database, I noticed that some people signed
up with junk email addresses. I'd like to put a stop to that.

I loosely followed [the :confirmable guide on the Devise wiki](https://github.com/plataformatec/devise/wiki/How-To:-Add-:confirmable-to-Users).

Fixes #119 