### PR TITLE
Send POST data and cookies with Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,6 @@
+Raven.configure do |config|
+  config.processors -= [Raven::Processor::PostData] # Send POST data
+  config.processors -= [Raven::Processor::Cookies]  # Send cookies
+
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end


### PR DESCRIPTION
There's a caveat here wherein I assume that `config/initializers/filter_parameter_logging.rb` is loaded before this file as it modifies `Rails.application.config.filter_parameters`. I suppose if the load order ever changes, I'll have to move this Raven configuration into `config/application.rb` or somewhere like that.