### PR TITLE
Allow deploy without remote server having SSH access

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock "3.10.1"
 
 set :application, "timesheet"
-set :repo_url, "git@github.com:J3RN/timesheet.git"
+set :repo_url, "https://github.com/J3RN/timesheet.git"
 
 # Set RVM as system
 set :rvm_type, :system


### PR DESCRIPTION
Previous to this change, the remote server would have to use SSH
authentication with GitHub to deploy. Since this repository is public,
that's unnecessary; the server can clone the repo over HTTPS.