### PR TITLE
Shorten long duration string if no minutes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,10 +21,11 @@ module ApplicationHelper
     hours = minutes / 60
     minutes = minutes % 60
 
-    hour_string = "hour".pluralize(hours)
-    minute_string = "minute".pluralize(minutes)
+    hour_string = "#{hours} hour".pluralize(hours)
+    return hour_string if minutes.zero?
 
-    "#{hours} #{hour_string} and #{minutes} #{minute_string}"
+    minute_string = "#{minutes} minute".pluralize(minutes)
+    "#{hour_string} and #{minute_string}"
   end
 
   def task_with_tag_labels(task)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -14,6 +14,8 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_dom_equal "11 hours and 11 minutes", long_duration_display(671)
     assert_dom_equal "1 hour and 2 minutes", long_duration_display(62)
     assert_dom_equal "2 hours and 1 minute", long_duration_display(121)
-    assert_dom_equal "0 hours and 0 minutes", long_duration_display(0)
+    assert_dom_equal "5 hours", long_duration_display(300)
+    assert_dom_equal "1 hour", long_duration_display(60)
+    assert_dom_equal "0 hours", long_duration_display(0)
   end
 end


### PR DESCRIPTION
Instead of displaying a string like "1 hour and 0 minutes", just display "1 hour"