### PR TITLE
Disallow interaction with the future

### DIFF
--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -7,6 +7,7 @@ class TimeEntry < ApplicationRecord
 
   validates_presence_of :task_id
   validates_presence_of :user_id
+  validates :start_time, historic: true
 
   scope :filter_by_date, lambda { |date|
     today = date.to_time

--- a/app/validators/historic_validator.rb
+++ b/app/validators/historic_validator.rb
@@ -1,0 +1,7 @@
+class HistoricValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value <= Time.now
+
+    record.errors[attribute] << (options[:message] || "is in the future")
+  end
+end

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -5,7 +5,9 @@
     <div class="btn-group time-nav">
       <%= link_to "<<", time_entries_path(date: @date - 1.day), class: 'btn btn-default' %>
       <%= link_to "Today", time_entries_path, class: 'btn btn-default' %>
-      <%= link_to ">>", time_entries_path(date: @date + 1.day), class: 'btn btn-default' %>
+      <% if @date < Date.today %>
+        <%= link_to ">>", time_entries_path(date: @date + 1.day), class: 'btn btn-default' %>
+      <% end %>
     </div>
   </div>
 </h1>


### PR DESCRIPTION
This PR fixes #133, whose primary concern was with being able to browse into the future, and create time entries that start in the future. Both of those concerns are fixed with this PR.

My largest concern with this change—and it's a minor one—is the word "historic" meaning present-and-past. Honestly, though, I've really quite come around to it.